### PR TITLE
add AbstractExchangeBotSnapshotCollector

### DIFF
--- a/octobot_backtesting/api/__init__.py
+++ b/octobot_backtesting/api/__init__.py
@@ -52,6 +52,7 @@ from octobot_backtesting.api.backtesting import (
 )
 from octobot_backtesting.api.exchange_data_collector import (
     exchange_historical_data_collector_factory,
+    exchange_bot_snapshot_data_collector_factory,
     initialize_and_run_data_collector,
     stop_data_collector,
     is_data_collector_in_progress,
@@ -83,6 +84,7 @@ __all__ = [
     "stop_backtesting",
     "stop_independent_backtesting",
     "exchange_historical_data_collector_factory",
+    "exchange_bot_snapshot_data_collector_factory",
     "initialize_and_run_data_collector",
     "stop_data_collector",
     "is_data_collector_in_progress",

--- a/octobot_backtesting/api/exchange_data_collector.py
+++ b/octobot_backtesting/api/exchange_data_collector.py
@@ -22,8 +22,37 @@ def exchange_historical_data_collector_factory(exchange_name,
                                                symbols,
                                                time_frames=None,
                                                start_timestamp=None,
-                                               end_timestamp=None) -> str:
-    collector_class = tentacles_management.get_single_deepest_child_class(collectors.AbstractExchangeHistoryCollector)
+                                               end_timestamp=None):
+    return _exchange_collector_factory(collectors.AbstractExchangeHistoryCollector,
+                                       exchange_name,
+                                       tentacles_setup_config,
+                                       symbols,
+                                       time_frames,
+                                       start_timestamp,
+                                       end_timestamp)
+
+
+def exchange_bot_snapshot_data_collector_factory(exchange_name,
+                                                 tentacles_setup_config,
+                                                 symbols,
+                                                 exchange_id,
+                                                 time_frames=None,
+                                                 start_timestamp=None,
+                                                 end_timestamp=None):
+    collector = _exchange_collector_factory(collectors.AbstractExchangeBotSnapshotCollector,
+                                            exchange_name,
+                                            tentacles_setup_config,
+                                            symbols,
+                                            time_frames,
+                                            start_timestamp,
+                                            end_timestamp)
+    collector.register_exchange_id(exchange_id)
+    return collector
+
+
+def _exchange_collector_factory(collector_parent_class, exchange_name, tentacles_setup_config, symbols,
+                                time_frames, start_timestamp, end_timestamp):
+    collector_class = tentacles_management.get_single_deepest_child_class(collector_parent_class)
     collector_instance = collector_class({}, exchange_name, tentacles_setup_config, symbols, time_frames,
                                          use_all_available_timeframes=time_frames is None,
                                          start_timestamp=start_timestamp, end_timestamp=end_timestamp)

--- a/octobot_backtesting/collectors/__init__.pxd
+++ b/octobot_backtesting/collectors/__init__.pxd
@@ -23,6 +23,7 @@ from octobot_backtesting.collectors.data_collector cimport (
 from octobot_backtesting.collectors cimport exchanges
 from octobot_backtesting.collectors.exchanges cimport (
     ExchangeDataCollector,
+    AbstractExchangeBotSnapshotCollector,
     AbstractExchangeHistoryCollector,
     AbstractExchangeLiveCollector,
 )
@@ -36,6 +37,7 @@ from octobot_backtesting.collectors.social cimport (
 __all__ = [
     "DataCollector",
     "ExchangeDataCollector",
+    "AbstractExchangeBotSnapshotCollector",
     "AbstractExchangeHistoryCollector",
     "AbstractExchangeLiveCollector",
     "SocialDataCollector",

--- a/octobot_backtesting/collectors/__init__.py
+++ b/octobot_backtesting/collectors/__init__.py
@@ -22,6 +22,7 @@ from octobot_backtesting.collectors.data_collector import (
 from octobot_backtesting.collectors import exchanges
 from octobot_backtesting.collectors.exchanges import (
     ExchangeDataCollector,
+    AbstractExchangeBotSnapshotCollector,
     AbstractExchangeHistoryCollector,
     AbstractExchangeLiveCollector,
 )
@@ -35,6 +36,7 @@ from octobot_backtesting.collectors.social import (
 __all__ = [
     "DataCollector",
     "ExchangeDataCollector",
+    "AbstractExchangeBotSnapshotCollector",
     "AbstractExchangeHistoryCollector",
     "AbstractExchangeLiveCollector",
     "SocialDataCollector",

--- a/octobot_backtesting/collectors/data_collector.py
+++ b/octobot_backtesting/collectors/data_collector.py
@@ -17,6 +17,8 @@ import asyncio
 import json
 import os.path as path
 import os
+import time
+
 import aiohttp
 
 import octobot_commons.logging as logging
@@ -38,7 +40,9 @@ class DataCollector:
         self.logger = logging.get_logger(self.__class__.__name__)
 
         self.should_stop = False
-        self.file_name = data.get_backtesting_file_name(self.__class__, data_format)
+        self.file_name = data.get_backtesting_file_name(self.__class__,
+                                                        self.get_file_identifier,
+                                                        data_format=data_format)
 
         self.database = None
         self.aiohttp_session = None
@@ -51,6 +55,9 @@ class DataCollector:
 
     async def initialize(self) -> None:
         pass
+
+    def get_file_identifier(self):
+        return time.time()
 
     async def stop(self, **kwargs) -> None:
         self.should_stop = True

--- a/octobot_backtesting/collectors/exchanges/__init__.pxd
+++ b/octobot_backtesting/collectors/exchanges/__init__.pxd
@@ -20,9 +20,13 @@ from octobot_backtesting.collectors.exchanges.exchange_collector cimport (
     ExchangeDataCollector,
 )
 
+from octobot_backtesting.collectors.exchanges cimport abstract_exchange_bot_snapshot_collector
 from octobot_backtesting.collectors.exchanges cimport abstract_exchange_history_collector
 from octobot_backtesting.collectors.exchanges cimport abstract_exchange_live_collector
 
+from octobot_backtesting.collectors.exchanges.abstract_exchange_bot_snapshot_collector cimport (
+    AbstractExchangeBotSnapshotCollector,
+)
 from octobot_backtesting.collectors.exchanges.abstract_exchange_history_collector cimport (
     AbstractExchangeHistoryCollector,
 )
@@ -32,6 +36,7 @@ from octobot_backtesting.collectors.exchanges.abstract_exchange_live_collector c
 
 __all__ = [
     "ExchangeDataCollector",
+    "AbstractExchangeBotSnapshotCollector",
     "AbstractExchangeHistoryCollector",
     "AbstractExchangeLiveCollector",
 ]

--- a/octobot_backtesting/collectors/exchanges/__init__.py
+++ b/octobot_backtesting/collectors/exchanges/__init__.py
@@ -19,9 +19,13 @@ from octobot_backtesting.collectors.exchanges.exchange_collector import (
     ExchangeDataCollector,
 )
 
+from octobot_backtesting.collectors.exchanges import abstract_exchange_bot_snapshot_collector
 from octobot_backtesting.collectors.exchanges import abstract_exchange_history_collector
 from octobot_backtesting.collectors.exchanges import abstract_exchange_live_collector
 
+from octobot_backtesting.collectors.exchanges.abstract_exchange_bot_snapshot_collector import (
+    AbstractExchangeBotSnapshotCollector,
+)
 from octobot_backtesting.collectors.exchanges.abstract_exchange_history_collector import (
     AbstractExchangeHistoryCollector,
 )
@@ -31,6 +35,7 @@ from octobot_backtesting.collectors.exchanges.abstract_exchange_live_collector i
 
 __all__ = [
     "ExchangeDataCollector",
+    "AbstractExchangeBotSnapshotCollector",
     "AbstractExchangeHistoryCollector",
     "AbstractExchangeLiveCollector",
 ]

--- a/octobot_backtesting/collectors/exchanges/abstract_exchange_bot_snapshot_collector.pxd
+++ b/octobot_backtesting/collectors/exchanges/abstract_exchange_bot_snapshot_collector.pxd
@@ -1,0 +1,20 @@
+#  Drakkar-Software OctoBot
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+cimport octobot_backtesting.collectors.exchanges as exchanges
+
+
+cdef class AbstractExchangeBotSnapshotCollector(exchanges.ExchangeDataCollector):
+    pass

--- a/octobot_backtesting/collectors/exchanges/abstract_exchange_bot_snapshot_collector.py
+++ b/octobot_backtesting/collectors/exchanges/abstract_exchange_bot_snapshot_collector.py
@@ -1,0 +1,20 @@
+#  Drakkar-Software OctoBot
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+import octobot_backtesting.collectors.exchanges.exchange_collector as exchange_collector
+
+
+class AbstractExchangeBotSnapshotCollector(exchange_collector.ExchangeDataCollector):
+    pass

--- a/octobot_backtesting/collectors/exchanges/exchange_collector.py
+++ b/octobot_backtesting/collectors/exchanges/exchange_collector.py
@@ -23,6 +23,8 @@ import octobot_commons.constants as commons_constants
 import octobot_backtesting.collectors.data_collector as data_collector
 import octobot_backtesting.enums as enums
 import octobot_backtesting.importers as importers
+import octobot_backtesting.errors as errors
+import octobot_commons.time_frame_manager as time_frame_manager
 
 try:
     import octobot_trading.constants as trading_constants
@@ -47,7 +49,11 @@ class ExchangeDataCollector(data_collector.DataCollector):
         self.current_step_index = 0
         self.total_steps = 0
         self.current_step_percent = 0
+        self.exchange_id = None
         self.set_file_path()
+
+    def register_exchange_id(self, exchange_id):
+        self.exchange_id = exchange_id
 
     def get_current_step_index(self):
         return self.current_step_index
@@ -57,6 +63,17 @@ class ExchangeDataCollector(data_collector.DataCollector):
 
     def get_current_step_percent(self):
         return self.current_step_percent
+
+    async def check_timestamps(self):
+        if self.start_timestamp is not None:
+            lowest_timestamp = min([await self.get_first_candle_timestamp(symbol,
+                                                                          time_frame_manager.find_min_time_frame(
+                                                                              self.time_frames))
+                                    for symbol in self.symbols])
+            if lowest_timestamp > self.start_timestamp:
+                self.start_timestamp = lowest_timestamp
+            if self.start_timestamp > (self.end_timestamp if self.end_timestamp else (time.time() * 1000)):
+                raise errors.DataCollectorError("start_timestamp is higher than end_timestamp")
 
     @abc.abstractmethod
     def _load_all_available_timeframes(self):

--- a/octobot_backtesting/data/data_file_manager.py
+++ b/octobot_backtesting/data/data_file_manager.py
@@ -29,9 +29,9 @@ import octobot_backtesting.enums as enums
 import octobot_backtesting.errors as errors
 
 
-def get_backtesting_file_name(clazz, data_format=enums.DataFormats.REGULAR_COLLECTOR_DATA):
+def get_backtesting_file_name(clazz, identifier, data_format=enums.DataFormats.REGULAR_COLLECTOR_DATA):
     return f"{clazz.__name__}{constants.BACKTESTING_DATA_FILE_SEPARATOR}" \
-           f"{time.time()}{get_file_ending(data_format)}"
+           f"{identifier()}{get_file_ending(data_format)}"
 
 
 def get_data_type(file_name):

--- a/octobot_backtesting/data/database.py
+++ b/octobot_backtesting/data/database.py
@@ -100,12 +100,26 @@ class DataBase:
 
         await self.__execute_insert(table, ", ".join(insert_values))
 
+    async def update(self, table, updated_value_by_column, **kwargs):
+        # Insert a row of data
+        updating_values = [f"{key} = '{value}'" for key, value in updated_value_by_column.items()]
+        await self.__execute_update(table,
+                                    ', '.join(updating_values),
+                                    self.__where_clauses_from_kwargs(**kwargs))
+
     def __insert_values(self, timestamp, inserting_values) -> str:
         return f"({timestamp}, {inserting_values})"
 
     async def __execute_insert(self, table, insert_items) -> None:
         async with self.aio_cursor() as cursor:
             await cursor.execute(f"INSERT INTO {table.value} VALUES {insert_items}")
+
+        # Save (commit) the changes
+        await self.connection.commit()
+
+    async def __execute_update(self, table, update_items, where_clauses) -> None:
+        async with self.aio_cursor() as cursor:
+            await cursor.execute(f"UPDATE {table.value} SET {update_items} WHERE {where_clauses}")
 
         # Save (commit) the changes
         await self.connection.commit()

--- a/octobot_backtesting/errors.py
+++ b/octobot_backtesting/errors.py
@@ -22,6 +22,10 @@ class DataCollectorError(Exception):
     pass
 
 
+class IncompatibleDatafileError(Exception):
+    pass
+
+
 class MissingTimeFrame(Exception):
     pass
 

--- a/octobot_backtesting/importers/exchanges/exchange_importer.pxd
+++ b/octobot_backtesting/importers/exchanges/exchange_importer.pxd
@@ -24,8 +24,13 @@ cdef class ExchangeDataImporter(importers.DataImporter):
     cdef public list time_frames
 
     cdef tuple __get_operations_from_timestamps(self, double superior_timestamp, double inferior_timestamp)
-    cdef list import_ohlcvs(self, list ohlcvs)
-    cdef list import_tickers(self, list tickers)
-    cdef list import_klines(self, list klines)
-    cdef list import_order_books(self, list order_books)
-    cdef list import_recent_trades(self, list recent_trades)
+    @staticmethod
+    cdef list import_ohlcvs(list ohlcvs)
+    @staticmethod
+    cdef list import_tickers(list tickers)
+    @staticmethod
+    cdef list import_klines(list klines)
+    @staticmethod
+    cdef list import_order_books(list order_books)
+    @staticmethod
+    cdef list import_recent_trades(list recent_trades)

--- a/octobot_backtesting/importers/exchanges/exchange_importer.py
+++ b/octobot_backtesting/importers/exchanges/exchange_importer.py
@@ -114,7 +114,8 @@ class ExchangeDataImporter(importers.DataImporter):
 
         return timestamps, operations
 
-    def import_ohlcvs(self, ohlcvs):
+    @staticmethod
+    def import_ohlcvs(ohlcvs):
         for i, val in enumerate(ohlcvs):
             ohlcvs[i] = list(val)
             # ohlcvs[i][-2] = TimeFrames(ohlcvs[i][-2])
@@ -139,7 +140,8 @@ class ExchangeDataImporter(importers.DataImporter):
                                                                             timestamps=timestamps,
                                                                             operations=operations))
 
-    def import_tickers(self, tickers):
+    @staticmethod
+    def import_tickers(tickers):
         for ticker in tickers:
             ticker[-1] = json.loads(ticker[-1])
         return tickers
@@ -156,7 +158,8 @@ class ExchangeDataImporter(importers.DataImporter):
                                                                              timestamps=timestamps,
                                                                              operations=operations))
 
-    def import_order_books(self, order_books):
+    @staticmethod
+    def import_order_books(order_books):
         for order_book in order_books:
             order_book[-1] = json.loads(order_book[-1])
             order_book[-2] = json.loads(order_book[-2])
@@ -174,7 +177,8 @@ class ExchangeDataImporter(importers.DataImporter):
                                                       exchange_name=exchange_name, symbol=symbol,
                                                       timestamps=timestamps, operations=operations))
 
-    def import_recent_trades(self, recent_trades):
+    @staticmethod
+    def import_recent_trades(recent_trades):
         for recent_trade in recent_trades:
             recent_trade[-1] = json.loads(recent_trade[-1])
         return recent_trades
@@ -194,7 +198,8 @@ class ExchangeDataImporter(importers.DataImporter):
                                                                              timestamps=timestamps,
                                                                              operations=operations))
 
-    def import_klines(self, klines):
+    @staticmethod
+    def import_klines(klines):
         for kline in klines:
             kline[-1] = json.loads(kline[-1])
         return klines

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ packages_list = [
     "octobot_backtesting.util.backtesting_util",
     "octobot_backtesting.collectors.data_collector",
     "octobot_backtesting.collectors.exchanges.exchange_collector",
+    "octobot_backtesting.collectors.exchanges.abstract_exchange_bot_snapshot_collector",
     "octobot_backtesting.collectors.exchanges.abstract_exchange_history_collector",
     "octobot_backtesting.collectors.exchanges.abstract_exchange_live_collector",
     "octobot_backtesting.collectors.social.social_collector",


### PR DESCRIPTION
AbstractExchangeBotSnapshotCollector is used to create backtesting files from the currently available data from the running bot

collector added here https://github.com/Drakkar-Software/OctoBot-Tentacles/pull/591/commits/2e0aa126169ea10ea29f11cf9ada052071997d3f